### PR TITLE
fix: remove git hooks from the update ci workflow

### DIFF
--- a/tests/unit/test_cookiecutter_generation.py
+++ b/tests/unit/test_cookiecutter_generation.py
@@ -98,7 +98,7 @@ def test_flakehell_passes(
             "   --output-file requirements-dev.txt; "
             "pip install -r requirements-dev.txt; "
             "pip install -e .; "
-            "black .; "
+            "black --exclude env .; "
             "flakehell lint src tests",
             _cwd=str(result.project),
         )

--- a/{{cookiecutter.project_slug}}/.github/workflows/update.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/update.yml
@@ -26,6 +26,7 @@ jobs:
         run: make all
       - name: Commit files
         run: |
+          rm -r .git/hooks
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add requirements.txt docs/requirements.txt requirements-dev.txt


### PR DESCRIPTION
Otherwise pre-commit sometimes makes the jobs fail with the error

error: pathspec 'master' did not match any file(s) known to git

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->


## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
