### PR TITLE
feat: disable github integration on cookiecutter creation

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -326,8 +326,10 @@ def main() -> None:
 #########################"""
     )
 
-    password_store = passpy.Store()
-    configure_github_repository(password_store)
+    # We need to migrate these steps to autodev instead. A cookiecutter should not
+    # interact with third party services.
+    # password_store = passpy.Store()
+    # configure_github_repository(password_store)
     clean_unwanted_directories()
 
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -326,10 +326,11 @@ def main() -> None:
 #########################"""
     )
 
+    # E800: Found commented out code
     # We need to migrate these steps to autodev instead. A cookiecutter should not
     # interact with third party services.
-    # password_store = passpy.Store()
-    # configure_github_repository(password_store)
+    # password_store = passpy.Store() # noqa: E800
+    # configure_github_repository(password_store) # noqa: E800
     clean_unwanted_directories()
 
 


### PR DESCRIPTION
A cookiecutter should not interact with third party services.

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->


## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
