### PR TITLE
feat: Configure black to drop python 3.6 and use python 3.9 and 3.10 instead

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -86,7 +86,7 @@ def clean_unwanted_directories() -> None:
     # fmt: off
     remove_paths = [
         '{% if cookiecutter.configure_command_line != "True" %} tests/e2e/test_cli.py {% endif %}', # noqa
-        '{% if cookiecutter.configure_command_line != "True" %} src/cli.py {% endif %}',
+        '{% if cookiecutter.configure_command_line != "True" %} src/{{cookiecutter.project_slug}}/entrypoints/cli.py {% endif %}', # noqa
         '{% if cookiecutter.read_configuration_from_yaml != "True" %} assets {% endif %}', # noqa
         '{% if cookiecutter.read_configuration_from_yaml != "True" %} tests/unit/test_config.py {% endif %}', # noqa
         '{% if cookiecutter.read_configuration_from_yaml != "True" %} tests/assets {% endif %}', # noqa

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -9,21 +9,21 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
   - repo: https://github.com/ambv/black
-    rev: main
+    rev: 21.10b0
     hooks:
       - id: black
         language_version: python3.7
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.782
+    rev: v0.910-1
     hooks:
       - name: Run mypy static analysis tool
         id: mypy
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.1.3
+    rev: v1.2.2
     hooks:
       - id: python-safety-dependencies-check
   - repo: https://github.com/flakehell/flakehell/
-    rev: master
+    rev: v.0.9.0
     hooks:
       - name: Run flakehell static analysis tool
         id: flakehell

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -12,7 +12,7 @@ version_files = [
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_underscore_slug}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_underscore_slug}}/__init__.py
@@ -1,5 +1,1 @@
 """{{ cookiecutter.project_description }}."""
-
-from typing import List
-
-__all__: List[str] = []

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_underscore_slug}}/model.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_underscore_slug}}/model.py
@@ -1,0 +1,1 @@
+"""Define the data models of the program."""

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_underscore_slug}}/model/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_underscore_slug}}/model/__init__.py
@@ -1,4 +1,0 @@
-"""Module to store the common business model of all entities.
-
-Abstract Classes:
-"""

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_underscore_slug}}/services.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_underscore_slug}}/services.py
@@ -1,4 +1,4 @@
-"""Gather all the orchestration functionality required by the program to work.
+"""Define all the orchestration functionality required by the program to work.
 
 Classes and functions that connect the different domain model objects with the adapters
 and handlers to achieve the program's purpose.


### PR DESCRIPTION
fix(template): remove the __all__ at init level

As most packages don't need it, it's better to manually add it when
needed.

fix(template): remove models directory and create model.py

At the start of the projects you usually don't need the directory, with
a file you can start up, and if you need it you can refactor afterwards

fix(template): correct the path to remove the cli.py entrypoint if it's not configured

perf: upgrade the versions of the pre-commits

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->


## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
