### PR TITLE
fix: remove the markdown_include mkdocs plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-code:
 	@echo ""
 
 .PHONY: all
-all: lint mypy test security
+all: lint mypy test security build-docs
 
 .PHONY: clean
 clean:
@@ -126,7 +126,7 @@ build-docs:
 	@echo "- Building documentation -"
 	@echo "--------------------------"
 
-	pdm run mkdocs build
+	pdm run mkdocs build --strict
 
 	@echo ""
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -170,7 +170,7 @@ build-docs:
 	@echo "- Building documentation -"
 	@echo "--------------------------"
 
-	pdm run mkdocs build
+	pdm run mkdocs build --strict
 
 	@echo ""
 

--- a/{{cookiecutter.project_slug}}/mkdocs.yml
+++ b/{{cookiecutter.project_slug}}/mkdocs.yml
@@ -33,8 +33,6 @@ markdown_extensions:
   - abbr
   - def_list
   - admonition
-  - markdown_include.include:
-      base_path: docs
   - meta
   - toc:
       permalink: true


### PR DESCRIPTION
It started failing because it was using a deprecated option of
a downstream dependency, and it doesn't look that it's going to fix it,
as it hasn't had any development since 2020.

Also I'm not sure we're using it anyway

feat: run mkdocs build with strict mode

So that we catch documentation build errors

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->


## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
